### PR TITLE
UX: reduce occurrence, simplify single-stat cases, link color

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -24,7 +24,7 @@ body:not(.archetype-private_message) {
     .topic-map {
       box-sizing: border-box;
       margin: 0;
-      padding: 0.5em 0.5em 0.5em
+      padding: 0.5em 0 0.5em
         calc(var(--topic-body-width-padding) + var(--topic-avatar-width));
 
       @media screen and (max-width: 500px) {
@@ -405,12 +405,22 @@ body:not(.archetype-private_message) {
     .map > ul {
       flex-direction: row;
       gap: 1em;
-      .fk-d-menu__trigger {
-        &:hover {
-          .number,
-          .presentation {
-            color: var(--tertiary);
+      &.--single-stat {
+        button {
+          flex-direction: row;
+          gap: 0.25em;
+          h4,
+          span {
+            font-size: var(--font-0);
+            color: var(--primary-700) !important;
           }
+        }
+      }
+
+      .fk-d-menu__trigger {
+        .number,
+        .presentation {
+          color: var(--tertiary);
         }
 
         .mobile-view & {
@@ -461,6 +471,10 @@ body:not(.archetype-private_message) {
 .gap {
   // temporarily fixes missing dividing border between gap posts and map
   border-top: 1px solid var(--primary-low);
+  max-width: calc(
+    var(--topic-avatar-width) + var(--topic-body-width) +
+      (var(--topic-body-width-padding) * 2)
+  );
   padding-top: 0.5em;
 }
 
@@ -495,7 +509,7 @@ body:not(.archetype-private_message) {
         }
       }
 
-      @media screen and (max-width: 1075px) {
+      @media screen and (max-width: 1090px) {
         li.avatars {
           display: none;
         }

--- a/common/common.scss
+++ b/common/common.scss
@@ -36,7 +36,7 @@ body:not(.archetype-private_message) {
         line-height: 1.2;
       }
 
-      h4 {
+      span {
         margin: 0;
       }
 
@@ -163,7 +163,7 @@ body:not(.archetype-private_message) {
     }
 
     .mobile-view & {
-      h4 {
+      span {
         font-size: var(--font-down-1);
         @include breakpoint(mobile-large) {
           letter-spacing: 0.2px;
@@ -405,11 +405,19 @@ body:not(.archetype-private_message) {
     .map > ul {
       flex-direction: row;
       gap: 1em;
+
+      > button {
+        span {
+          font-size: var(--font-down-1);
+          color: var(--primary-medium);
+        }
+      }
+
       &.--single-stat {
         button {
           flex-direction: row;
           gap: 0.25em;
-          h4,
+
           span {
             font-size: var(--font-0);
             color: var(--primary-700) !important;

--- a/javascripts/discourse/components/revamped-topic-map.gjs
+++ b/javascripts/discourse/components/revamped-topic-map.gjs
@@ -18,9 +18,9 @@ export default class RevampedTopicMap extends Component {
       return;
     }
 
-    if (this.isOP && this.args.outletArgs.model.posts_count > 4) {
+    if (this.isOP) {
       return true;
-    } else if (!this.isOP) {
+    } else if (!this.isOP && this.args.outletArgs.model.posts_count > 10) {
       return true;
     }
   }

--- a/javascripts/discourse/components/simple-topic-map-summary.gjs
+++ b/javascripts/discourse/components/simple-topic-map-summary.gjs
@@ -180,6 +180,7 @@ export default class SimpleTopicMapSummary extends Component {
         this.mostLikedPosts = mostLikedPosts;
       })
       .catch((error) => {
+        // eslint-disable-next-line no-console
         console.error("Error fetching posts:", error);
       })
       .finally(() => {
@@ -200,15 +201,15 @@ export default class SimpleTopicMapSummary extends Component {
 
   <template>
     <ul class={{if this.loneStat "--single-stat"}}>
-      <!-- to fix: button container and classes are a hack to match alignment of siblings -->
       <button
+        type="button"
         class="secondary views btn no-text fk-d-menu__trigger map-likes-trigger"
       >
         {{number @topic.views noTitle="true" class=@topic.viewsHeat}}
-        <h4 role="presentation">{{i18n
+        <span role="presentation">{{i18n
             "views_lowercase"
             count=@topic.views
-          }}</h4>
+          }}</span>
       </button>
 
       {{#if (and (gt @topic.like_count 5) (gt @topic.posts_count 10))}}
@@ -223,10 +224,10 @@ export default class SimpleTopicMapSummary extends Component {
         >
           <:trigger>
             {{number @topic.like_count noTitle="true"}}
-            <h4 role="presentation">{{i18n
+            <span role="presentation">{{i18n
                 "likes_lowercase"
                 count=@topic.like_count
-              }}</h4>
+              }}</span>
           </:trigger>
           <:content>
             <section class="likes" {{didInsert this.fetchMostLiked}}>
@@ -273,10 +274,10 @@ export default class SimpleTopicMapSummary extends Component {
         >
           <:trigger>
             {{number this.linksCount noTitle="true"}}
-            <h4 role="presentation">{{i18n
+            <span role="presentation">{{i18n
                 "links_lowercase"
                 count=this.linksCount
-              }}</h4>
+              }}</span>
           </:trigger>
           <:content>
             <section class="links">
@@ -339,10 +340,10 @@ export default class SimpleTopicMapSummary extends Component {
         >
           <:trigger>
             {{number @topic.participant_count noTitle="true"}}
-            <h4 role="presentation">{{i18n
+            <span role="presentation">{{i18n
                 "users_lowercase"
                 count=@topic.participant_count
-              }}</h4>
+              }}</span>
           </:trigger>
           <:content>
             <section class="avatars">


### PR DESCRIPTION
General changes: 

* When there's no summary available, and only a single stat (usually views), simplify:

  ![image](https://github.com/discourse/discourse-experimental-topic-map/assets/1681963/c6c65b95-beaf-4259-9841-2bc868494a76)


* Indicate that clickable stats are clickable: 

  ![image](https://github.com/discourse/discourse-experimental-topic-map/assets/1681963/2d1c5018-97c4-492c-a916-f3c772be592a)


* The topic map now shows at the top below OP for short topics (previously would always show at the bottom for short topics). It will only show at the bottom of topics with more than 10 posts

* Most liked post menu is now cached for 1 minute

Additionally, hiding low value information: 

* Hide low read estimates (under 3 minutes)
* Hide participant count if 5 or less 
* Show participant avatars if >= 10 posts  
* Hide likes when there are fewer than 5 likes or fewer than 10 posts 