### PR TITLE
UX: hide avatars dynamically, truncate long text

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -48,9 +48,25 @@ body:not(.archetype-private_message) {
       }
 
       li.avatars {
+        overflow: hidden;
+        height: 2em;
+        align-self: center;
+        flex: 1 2 0;
+        gap: 0.25em;
         .avatar-flair,
         .post-count {
           display: none;
+        }
+
+        div {
+          container-type: inline-size;
+          width: auto;
+          flex: 0 1 32px;
+          @container (max-width: 31px) {
+            a {
+              display: none;
+            }
+          }
         }
 
         .avatar {
@@ -82,6 +98,7 @@ body:not(.archetype-private_message) {
       align-items: center;
       padding: 0;
       background: transparent;
+      min-width: 0;
     }
   }
 
@@ -178,6 +195,7 @@ body:not(.archetype-private_message) {
     align-items: end;
     line-height: 1.2;
     color: var(--primary-high);
+    white-space: nowrap;
 
     span:first-child {
       font-size: var(--font-down-1);
@@ -404,12 +422,22 @@ body:not(.archetype-private_message) {
 
     .map > ul {
       flex-direction: row;
-      gap: 1em;
-
+      flex-wrap: nowrap;
+      gap: 0.75em;
       > button {
+        div {
+          display: flex;
+          min-width: 0;
+          width: 100%;
+          overflow: hidden;
+        }
         span {
+          display: block;
+          min-width: 0;
           font-size: var(--font-down-1);
           color: var(--primary-medium);
+          width: 100%;
+          @include ellipsis;
         }
       }
 
@@ -484,44 +512,4 @@ body:not(.archetype-private_message) {
       (var(--topic-body-width-padding) * 2)
   );
   padding-top: 0.5em;
-}
-
-// Hiding avatars at various breakpoints
-
-body:not(.archetype-private_message) {
-  .topic-map.--simplified {
-    @media screen and (max-width: 767px) {
-      li.avatars {
-        div:nth-child(4),
-        div:nth-child(5) {
-          display: none;
-        }
-      }
-    }
-
-    @media screen and (max-width: 650px) {
-      li.avatars {
-        display: none;
-      }
-    }
-  }
-
-  &.has-sidebar-page {
-    .topic-map.--simplified {
-      @media screen and (max-width: 1170px) {
-        li.avatars {
-          div:nth-child(4),
-          div:nth-child(5) {
-            display: none;
-          }
-        }
-      }
-
-      @media screen and (max-width: 1090px) {
-        li.avatars {
-          display: none;
-        }
-      }
-    }
-  }
 }


### PR DESCRIPTION
Instead of relying on breakpoints, this will hide any number of avatars based on the available width in the topic map by hiding them in overflow. This will make the layout a little more adjustable to long text in translations. 

I've also added `text-overflow: ellipsis;` to hide overflow in the worst cases, which will prevent the topic map from ever wrapping onto multiple lines. 