### PR TITLE
UX: add view count chart, cache service

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -12,6 +12,8 @@ body:not(.archetype-private_message) {
   }
 
   .revamped-topic-map {
+    --chart-line-color: var(--tertiary-medium);
+    --chart-point-color: var(--tertiary);
     max-width: calc(
       var(--topic-avatar-width) + var(--topic-body-width) +
         (var(--topic-body-width-padding) * 2)
@@ -109,6 +111,8 @@ body:not(.archetype-private_message) {
       margin-top: -0.5em;
     }
   }
+
+  .map-views-content,
   .map-likes-content,
   .map-links-content,
   .map-users-content,
@@ -129,6 +133,10 @@ body:not(.archetype-private_message) {
           max-width: 90dvw;
         }
       }
+    }
+
+    .d-modal__body {
+      width: 100%;
     }
 
     section,
@@ -170,6 +178,12 @@ body:not(.archetype-private_message) {
         }
       }
     }
+  }
+
+  .view-explainer {
+    color: var(--primary-700);
+    font-size: var(--font-down-1);
+    margin-top: 1em;
   }
 
   .estimated-read-time {
@@ -426,16 +440,8 @@ body:not(.archetype-private_message) {
       }
 
       .fk-d-menu__trigger {
-        .number,
-        .presentation {
+        .number {
           color: var(--tertiary);
-        }
-
-        .mobile-view & {
-          .number,
-          .presentation {
-            color: var(--tertiary);
-          }
         }
       }
     }

--- a/javascripts/discourse/components/topic-views-chart.gjs
+++ b/javascripts/discourse/components/topic-views-chart.gjs
@@ -1,0 +1,134 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import loadScript from "discourse/lib/load-script";
+
+export default class TopicViewsChart extends Component {
+  @tracked chart = null;
+
+  @action
+  async renderChart(element) {
+    await loadScript("/javascripts/Chart.min.js");
+
+    const data = this.args.views.stats.map((item) => ({
+      x: new Date(`${item.viewed_at}T00:00:00`).getTime(),
+      y: item.views,
+    }));
+
+    const context = element.getContext("2d");
+
+    let showLine = true;
+
+    // if there's only one point, center and hide the line
+    if (data.length === 1) {
+      showLine = false;
+      const singleDataPoint = data[0];
+      const bufferBefore = {
+        x: singleDataPoint.x - 86400000,
+      };
+      const bufferAfter = {
+        x: singleDataPoint.x + 86400000,
+      };
+      data.unshift(bufferBefore);
+      data.push(bufferAfter);
+    }
+
+    const chartMin = Math.min(...data.map((item) => item.x));
+    const chartMax = Math.max(...data.map((item) => item.x));
+
+    const topicMapElement = document.querySelector(".revamped-topic-map");
+
+    const lineColor =
+      getComputedStyle(topicMapElement).getPropertyValue("--chart-line-color");
+    const pointColor = getComputedStyle(topicMapElement).getPropertyValue(
+      "--chart-point-color"
+    );
+
+    if (this.chart) {
+      this.chart.destroy();
+    }
+
+    this.chart = new window.Chart(context, {
+      type: "line",
+      data: {
+        datasets: [
+          {
+            label: "Views",
+            data,
+            showLine,
+            borderColor: pointColor,
+            backgroundColor: lineColor,
+            pointBackgroundColor: pointColor,
+            pointRadius: 3,
+            borderWidth: 2,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+
+        scales: {
+          x: {
+            type: "linear",
+            position: "bottom",
+            min: chartMin,
+            max: chartMax,
+            ticks: {
+              autoSkip: true,
+              maxTicksLimit: data.length,
+              callback: function (value) {
+                const date = new Date(value);
+                return date.toLocaleDateString(undefined, {
+                  month: "2-digit",
+                  day: "2-digit",
+                });
+              },
+            },
+          },
+          y: {
+            beginAtZero: true,
+            ticks: {
+              stepSize: 1, // whole numbers
+              callback: function (value) {
+                if (value < 100) {
+                  return value;
+                } else if (value < 1000) {
+                  return Math.round(value / 10) * 10;
+                } else if (value < 10000) {
+                  return Math.round(value / 100) * 100;
+                } else {
+                  return Math.round(value / 1000) * 1000;
+                }
+              },
+            },
+          },
+        },
+        plugins: {
+          legend: {
+            display: false,
+          },
+          tooltip: {
+            callbacks: {
+              title: function (tooltipItem) {
+                const date = new Date(tooltipItem[0]?.parsed?.x);
+                return date.toLocaleDateString(undefined, {
+                  month: "2-digit",
+                  day: "2-digit",
+                  year: "numeric",
+                });
+              },
+              label: function (tooltipItem) {
+                return `Views: ${tooltipItem?.parsed?.y}`;
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  <template>
+    <canvas {{didInsert this.renderChart}}></canvas>
+  </template>
+}

--- a/javascripts/discourse/services/map-cache.js
+++ b/javascripts/discourse/services/map-cache.js
@@ -1,0 +1,35 @@
+import Service from "@ember/service";
+
+export default class MapCache extends Service {
+  cache = {};
+
+  get(key) {
+    const cachedItem = this.cache[key];
+    if (!cachedItem) {
+      return null;
+    }
+
+    const { value, timestamp, ttl } = cachedItem;
+    const now = Date.now();
+
+    if (now - timestamp > ttl) {
+      this.clear(key);
+      return null;
+    }
+
+    return value;
+  }
+
+  set(key, value, ttl = 120000) {
+    // expires after 2 min
+    this.cache[key] = {
+      value,
+      timestamp: Date.now(),
+      ttl,
+    };
+  }
+
+  clear(key) {
+    delete this.cache[key];
+  }
+}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,5 +3,7 @@ en:
     description: ""
   menu_titles:
     replies: "Most liked replies"
+    views: Recent views
+  view_explainer: One view per unique visitor every 8 hours.
   read: read
   minutes: min


### PR DESCRIPTION
This uses the new view-stats endpoint to populate a chart for views:

![image](https://github.com/discourse/discourse-experimental-topic-map/assets/1681963/ee3f4d56-3642-4b0b-9158-6aa9840e3aa4)

I've also moved cache to a service