### PR TITLE
UX: allow user cards, switch to bar chart, cleanup

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -12,8 +12,7 @@ body:not(.archetype-private_message) {
   }
 
   .revamped-topic-map {
-    --chart-line-color: var(--tertiary-medium);
-    --chart-point-color: var(--tertiary);
+    --chart-bar-color: var(--tertiary);
     max-width: calc(
       var(--topic-avatar-width) + var(--topic-body-width) +
         (var(--topic-body-width-padding) * 2)
@@ -23,7 +22,9 @@ body:not(.archetype-private_message) {
       font-size: var(--font-down-1);
     }
 
-    .topic-map {
+    > .topic-map {
+      // topic-map class is resued within summaries for now,
+      // shouldn't need the child combinator when moved to core
       box-sizing: border-box;
       margin: 0;
       padding: 0.5em 0 0.5em
@@ -47,6 +48,9 @@ body:not(.archetype-private_message) {
           padding: 0;
           float: none;
         }
+        .d-icon {
+          font-size: var(--font-0); // core rule messes up menu caret
+        }
       }
 
       li.avatars {
@@ -57,6 +61,7 @@ body:not(.archetype-private_message) {
         gap: 0.25em;
         .avatar-flair,
         .post-count {
+          // removed intentionally to simplify
           display: none;
         }
 
@@ -74,12 +79,6 @@ body:not(.archetype-private_message) {
         .avatar {
           width: 2em;
           height: 2em;
-        }
-      }
-
-      @media screen and (max-width: 600px) {
-        li.avatars {
-          display: none;
         }
       }
     }
@@ -104,36 +103,11 @@ body:not(.archetype-private_message) {
     }
   }
 
-  [data-identifier="map-likes"],
-  [data-identifier="map-links"] {
-    .fk-d-menu__inner-content,
-    .d-modal__container {
-      padding-bottom: 0.5em !important;
-    }
-    h3 {
-      margin-top: -1.5rem;
-      background: var(--secondary);
-      position: sticky;
-      padding: 0.75rem 0 0.25rem;
-      top: -1.5rem;
-      z-index: 2;
-    }
-    a {
-      overflow-wrap: anywhere;
-    }
+  a {
+    overflow-wrap: anywhere;
   }
 
-  [data-identifier="map-users"] {
-    h3 {
-      margin-top: -0.5em;
-    }
-  }
-
-  .map-views-content,
-  .map-likes-content,
-  .map-links-content,
-  .map-users-content,
-  .map-summary-content {
+  .fk-d-menu__content {
     .fk-d-menu__inner-content,
     .d-modal__container {
       box-sizing: border-box;
@@ -143,7 +117,6 @@ body:not(.archetype-private_message) {
       overflow: auto;
       align-items: start;
       overscroll-behavior: contain;
-      padding: 1.5em;
       .desktop-view & {
         @include breakpoint(mobile-large) {
           min-width: unset;
@@ -156,9 +129,24 @@ body:not(.archetype-private_message) {
       width: 100%;
     }
 
-    section,
     .loading-container {
       width: 100%;
+    }
+
+    .toggle-summary,
+    section {
+      box-sizing: border-box;
+      border: none;
+      padding: 1.5em;
+      width: 100%;
+
+      h3 {
+        font-weight: bold;
+        font-size: var(--font-up-1);
+        margin-top: -0.35em;
+        margin-bottom: 0.5em;
+        width: 100%;
+      }
     }
 
     tbody {
@@ -175,25 +163,6 @@ body:not(.archetype-private_message) {
 
     td {
       padding: 0.5em 0;
-    }
-  }
-
-  .secondary.views {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    pointer-events: none;
-    .number {
-      color: var(--primary-high) !important; // override core heatmapping
-    }
-
-    .mobile-view & {
-      span {
-        font-size: var(--font-down-1);
-        @include breakpoint(mobile-large) {
-          letter-spacing: 0.2px;
-        }
-      }
     }
   }
 
@@ -242,18 +211,11 @@ body:not(.archetype-private_message) {
     .fk-d-menu__inner-content {
       max-height: 500px;
       max-width: 90vw;
+      overflow: auto;
 
       @media screen and (min-width: 400px) {
         width: 400px;
       }
-
-      overflow: auto;
-    }
-
-    .toggle-summary h3 {
-      font-size: var(--font-up-1);
-      font-weight: bold;
-      margin-bottom: 1em;
     }
 
     .toggle-summary .summary-box {
@@ -379,7 +341,7 @@ body:not(.archetype-private_message) {
       flex-wrap: wrap;
       gap: 0.5em;
       h3 {
-        width: 100%;
+        margin-bottom: 0.25em;
       }
     }
     .poster {
@@ -393,12 +355,14 @@ body:not(.archetype-private_message) {
     }
     .post-count {
       position: absolute;
-      z-index: 2;
-      border-radius: 1em;
-      padding: 0 0.4em;
-      font-size: var(--font-down-1);
-      right: -0.25em;
       top: 0;
+      right: 0;
+      border-radius: 100px;
+      padding: 0.15em 0.4em 0.2em;
+      text-align: center;
+      font-weight: normal;
+      font-size: var(--font-down-2);
+      line-height: var(--line-height-small);
     }
     .avatar-flair {
       position: absolute;

--- a/javascripts/discourse/components/simple-topic-map-summary.gjs
+++ b/javascripts/discourse/components/simple-topic-map-summary.gjs
@@ -29,6 +29,7 @@ const TRUNCATED_LINKS_LIMIT = 5;
 const MIN_POST_READ_TIME = 4;
 
 export default class SimpleTopicMapSummary extends Component {
+  @service site;
   @service siteSettings;
   @service mapCache;
 
@@ -72,7 +73,8 @@ export default class SimpleTopicMapSummary extends Component {
     return (
       this.args.collapsed &&
       this.args.topic.posts_count >= 10 &&
-      this.args.topicDetails.participants?.length >= 2
+      this.args.topicDetails.participants?.length >= 2 &&
+      !this.site.mobileView
     );
   }
 
@@ -233,6 +235,7 @@ export default class SimpleTopicMapSummary extends Component {
         @modalForMobile={{true}}
         @placement="right"
         @groupIdentifier="topic-map"
+        @inline={{true}}
       >
         <:trigger>
           {{number @topic.views noTitle="true"}}
@@ -249,11 +252,6 @@ export default class SimpleTopicMapSummary extends Component {
                 @views={{this.views}}
                 @created={{@topic.created_at}}
               />
-
-              <div class="view-explainer">{{i18n
-                  (themePrefix "view_explainer")
-                }}</div>
-
             </ConditionalLoadingSpinner>
           </section>
         </:content>
@@ -268,6 +266,7 @@ export default class SimpleTopicMapSummary extends Component {
           @modalForMobile={{true}}
           @placement="right"
           @groupIdentifier="topic-map"
+          @inline={{true}}
         >
           <:trigger>
             {{number @topic.like_count noTitle="true"}}
@@ -319,6 +318,7 @@ export default class SimpleTopicMapSummary extends Component {
           @modalForMobile={{true}}
           @groupIdentifier="topic-map"
           @placement="right"
+          @inline={{true}}
         >
           <:trigger>
             {{number this.linksCount noTitle="true"}}
@@ -385,6 +385,7 @@ export default class SimpleTopicMapSummary extends Component {
           @placement="right"
           @modalForMobile={{true}}
           @groupIdentifier="topic-map"
+          @inline={{true}}
         >
           <:trigger>
             {{number @topic.participant_count noTitle="true"}}
@@ -433,6 +434,7 @@ export default class SimpleTopicMapSummary extends Component {
               @placement="left"
               @modalForMobile={{true}}
               @groupIdentifier="topic-map"
+              @inline={{true}}
             >
               <:trigger>
                 <DButton

--- a/javascripts/discourse/components/topic-views-chart.gjs
+++ b/javascripts/discourse/components/topic-views-chart.gjs
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import loadScript from "discourse/lib/load-script";
+import i18n from "discourse-common/helpers/i18n";
 
 function calculateAdjustedStepSize(data) {
   const range =
@@ -20,10 +21,15 @@ function calculateAdjustedStepSize(data) {
 
 export default class TopicViewsChart extends Component {
   @tracked chart = null;
+  @tracked noData = false;
 
   @action
   async renderChart(element) {
     await loadScript("/javascripts/Chart.min.js");
+
+    if (!this.args.views?.stats || this.args.views?.stats?.length === 0) {
+      this.noData = true;
+    }
 
     const data = this.args.views.stats.map((item) => ({
       x: new Date(`${item.viewed_at}T00:00:00`).getTime(),
@@ -32,20 +38,14 @@ export default class TopicViewsChart extends Component {
 
     const context = element.getContext("2d");
 
-    let showLine = true;
-
-    // if there's only one point, center and hide the line
+    // if there's only one point, add previous day 0
     if (data.length === 1) {
-      showLine = false;
       const singleDataPoint = data[0];
       const bufferBefore = {
         x: singleDataPoint.x - 86400000,
       };
-      const bufferAfter = {
-        x: singleDataPoint.x + 86400000,
-      };
+
       data.unshift(bufferBefore);
-      data.push(bufferAfter);
     }
 
     const xMin = Math.min(...data.map((item) => item.x));
@@ -56,29 +56,21 @@ export default class TopicViewsChart extends Component {
 
     const topicMapElement = document.querySelector(".revamped-topic-map");
 
-    const lineColor =
-      getComputedStyle(topicMapElement).getPropertyValue("--chart-line-color");
-    const pointColor = getComputedStyle(topicMapElement).getPropertyValue(
-      "--chart-point-color"
-    );
+    const barColor =
+      getComputedStyle(topicMapElement).getPropertyValue("--chart-bar-color");
 
     if (this.chart) {
       this.chart.destroy();
     }
 
     this.chart = new window.Chart(context, {
-      type: "line",
+      type: "bar",
       data: {
         datasets: [
           {
             label: "Views",
             data,
-            showLine,
-            borderColor: pointColor,
-            backgroundColor: lineColor,
-            pointBackgroundColor: pointColor,
-            pointRadius: 3,
-            borderWidth: 2,
+            backgroundColor: barColor,
           },
         ],
       },
@@ -137,6 +129,11 @@ export default class TopicViewsChart extends Component {
   }
 
   <template>
-    <canvas {{didInsert this.renderChart}}></canvas>
+    {{#if this.noData}}
+      {{i18n (themePrefix "no_views")}}
+    {{else}}
+      <canvas {{didInsert this.renderChart}}></canvas>
+      <div class="view-explainer">{{i18n (themePrefix "view_explainer")}}</div>
+    {{/if}}
   </template>
 }

--- a/javascripts/discourse/initializers/init-menu-card-click.js
+++ b/javascripts/discourse/initializers/init-menu-card-click.js
@@ -1,0 +1,15 @@
+import { apiInitializer } from "discourse/lib/api";
+
+export default apiInitializer("1.20.0", (api) => {
+  const site = api.container.lookup("service:site");
+  // enables user cards in the users menu
+
+  if (document.querySelector(".topic-map.--simplified")) {
+    api.addCardClickListenerSelector(".topic-map.--simplified");
+  }
+
+  if (site.mobileView) {
+    // workaround for now
+    api.addCardClickListenerSelector(".modal-container");
+  }
+});

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -5,5 +5,6 @@ en:
     replies: "Most liked replies"
     views: Recent views
   view_explainer: One view per unique visitor every 8 hours.
+  no_views: No view stats yet, check back later.
   read: read
   minutes: min


### PR DESCRIPTION
This allows user cards from the menus:

![image](https://github.com/discourse/discourse-experimental-topic-map/assets/1681963/ee870be6-2775-4e8b-b5e9-2559b469fa2d)

I've also switched the view menu chart to a bar chart, and cleaned up some styles and possible error states. 