### PR TITLE
DEV: follow-up, only need to enable usercards for mobile

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -483,3 +483,15 @@ body:not(.archetype-private_message) {
   );
   padding-top: 0.5em;
 }
+
+.mobile-view {
+  [class*="map-"] {
+    .d-modal__body {
+      padding: 1em 1em 2em 1em;
+
+      h3 {
+        width: 100%;
+      }
+    }
+  }
+}

--- a/javascripts/discourse/components/topic-views-chart.gjs
+++ b/javascripts/discourse/components/topic-views-chart.gjs
@@ -28,7 +28,7 @@ export default class TopicViewsChart extends Component {
     await loadScript("/javascripts/Chart.min.js");
 
     if (!this.args.views?.stats || this.args.views?.stats?.length === 0) {
-      this.noData = true;
+      return (this.noData = true);
     }
 
     const data = this.args.views.stats.map((item) => ({

--- a/javascripts/discourse/initializers/init-menu-card-click.js
+++ b/javascripts/discourse/initializers/init-menu-card-click.js
@@ -2,14 +2,10 @@ import { apiInitializer } from "discourse/lib/api";
 
 export default apiInitializer("1.20.0", (api) => {
   const site = api.container.lookup("service:site");
-  // enables user cards in the users menu
-
-  if (document.querySelector(".topic-map.--simplified")) {
-    api.addCardClickListenerSelector(".topic-map.--simplified");
-  }
-
+  //  workaround for now
+  // enables user cards in the mobile users modal
+  // by allowing usercards in all mobile modals
   if (site.mobileView) {
-    // workaround for now
     api.addCardClickListenerSelector(".modal-container");
   }
 });


### PR DESCRIPTION
Didn't actually need the desktop version because I also inlined the menus in 6fc6c89 and that solves the same issue as `addCardClickListenerSelector` was attempting to do