### PR TITLE
UX: add prediction for today's views, simple views count

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -14,6 +14,7 @@ body:not(.archetype-private_message) {
   .revamped-topic-map {
     --chart-line-color: var(--tertiary);
     --chart-point-color: var(--tertiary-medium);
+    --chart-prediction-color: var(--primary-low-mid);
 
     max-width: calc(
       var(--topic-avatar-width) + var(--topic-body-width) +
@@ -507,5 +508,41 @@ body:not(.archetype-private_message) {
   }
   td {
     padding: 0.5em 0;
+  }
+}
+
+.simple-view-count {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1 1 auto;
+  padding: 0.5em 1em 0;
+
+  &__wrapper {
+    display: flex;
+    width: 100%;
+    align-items: space-between;
+  }
+  &__views {
+    font-size: var(--font-up-4);
+    color: var(--primary-high);
+  }
+  &__so-far {
+    font-size: var(--font-down-1);
+    color: var(--primary-medium);
+    font-style: italic;
+  }
+  &__date {
+    font-size: var(--font-down-1);
+    color: var(--primary-medium);
+  }
+}
+
+.map-views-content:has(.simple-view-count) {
+  .fk-d-menu__inner-content {
+    min-width: unset !important; // override too-specific selector
+  }
+  h3 {
+    text-align: center;
   }
 }

--- a/javascripts/discourse/components/simple-topic-map-summary.gjs
+++ b/javascripts/discourse/components/simple-topic-map-summary.gjs
@@ -23,6 +23,7 @@ import DMenu from "float-kit/components/d-menu";
 import and from "truth-helpers/helpers/and";
 import lt from "truth-helpers/helpers/lt";
 import not from "truth-helpers/helpers/not";
+import SimpleViewCounts from "../components/simple-view-counts";
 import TopicViewsChart from "../components/topic-views-chart";
 
 const TRUNCATED_LINKS_LIMIT = 5;
@@ -245,13 +246,17 @@ export default class SimpleTopicMapSummary extends Component {
             }}</span>
         </:trigger>
         <:content>
-          <section class="views" {{didInsert this.fetchViews}}>
+          <section class="views topic-map-views" {{didInsert this.fetchViews}}>
             <h3>{{i18n (themePrefix "menu_titles.views")}}</h3>
             <ConditionalLoadingSpinner @condition={{this.loading}}>
-              <TopicViewsChart
-                @views={{this.views}}
-                @created={{@topic.created_at}}
-              />
+              {{#if (gt this.views.stats.length 2)}}
+                <TopicViewsChart
+                  @views={{this.views}}
+                  @created={{@topic.created_at}}
+                />
+              {{else}}
+                <SimpleViewCounts @views={{this.views}} />
+              {{/if}}
             </ConditionalLoadingSpinner>
           </section>
         </:content>

--- a/javascripts/discourse/components/simple-view-counts.gjs
+++ b/javascripts/discourse/components/simple-view-counts.gjs
@@ -5,18 +5,38 @@ import i18n from "discourse-common/helpers/i18n";
 export default class SimpleViewCounts extends Component {
   get updatedStats() {
     let stats = this.args.views.stats.map((stat, index, array) => {
+      let label = null;
+
+      const today = new Date().setHours(0, 0, 0, 0);
+      const yesterday = new Date(today - 86400000).setHours(0, 0, 0, 0);
+      const statDate = new Date(`${stat.viewed_at}T00:00:00`).setHours(
+        0,
+        0,
+        0,
+        0
+      );
+
+      if (array.length === 1 || statDate === today) {
+        label = "today";
+      } else if (statDate === yesterday) {
+        label = "yesterday";
+      }
+
       return {
         ...stat,
-        label:
-          array.length === 1 || index === array.length - 1
-            ? "today"
-            : index === array.length - 2
-            ? "yesterday"
-            : null,
+        label: label || this.formatDate(stat.viewed_at),
       };
     });
 
     return stats;
+  }
+
+  formatDate(date) {
+    const day = new Date(date);
+    return day.toLocaleDateString(undefined, {
+      month: "2-digit",
+      day: "2-digit",
+    });
   }
 
   <template>
@@ -27,14 +47,16 @@ export default class SimpleViewCounts extends Component {
             {{stat.views}}
           </div>
           <div class="simple-view-count__date">
-            {{i18n (themePrefix stat.label)}}
-            <span class="simple-view-count__so-far">
-              {{#if stat.label}}
-                {{#if (eq stat.label "today")}}
-                  {{i18n (themePrefix "so_far")}}
-                {{/if}}
-              {{/if}}
-            </span>
+            {{#if (eq stat.label "today")}}
+              {{i18n (themePrefix "today")}}
+              <span class="simple-view-count__so-far">
+                {{i18n (themePrefix "so_far")}}
+              </span>
+            {{else if (eq stat.label "yesterday")}}
+              {{i18n (themePrefix "yesterday")}}
+            {{else}}
+              {{stat.label}}
+            {{/if}}
           </div>
         </div>
       {{/each}}

--- a/javascripts/discourse/components/simple-view-counts.gjs
+++ b/javascripts/discourse/components/simple-view-counts.gjs
@@ -1,0 +1,43 @@
+import Component from "@glimmer/component";
+import { eq } from "truth-helpers";
+import i18n from "discourse-common/helpers/i18n";
+
+export default class SimpleViewCounts extends Component {
+  get updatedStats() {
+    let stats = this.args.views.stats.map((stat, index, array) => {
+      return {
+        ...stat,
+        label:
+          array.length === 1 || index === array.length - 1
+            ? "today"
+            : index === array.length - 2
+            ? "yesterday"
+            : null,
+      };
+    });
+
+    return stats;
+  }
+
+  <template>
+    <div class="simple-view-count__wrapper">
+      {{#each this.updatedStats as |stat|}}
+        <div class="simple-view-count">
+          <div class="simple-view-count__views">
+            {{stat.views}}
+          </div>
+          <div class="simple-view-count__date">
+            {{i18n (themePrefix stat.label)}}
+            <span class="simple-view-count__so-far">
+              {{#if stat.label}}
+                {{#if (eq stat.label "today")}}
+                  {{i18n (themePrefix "so_far")}}
+                {{/if}}
+              {{/if}}
+            </span>
+          </div>
+        </div>
+      {{/each}}
+    </div>
+  </template>
+}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,9 +2,13 @@ en:
   theme_metadata:
     description: ""
   menu_titles:
-    replies: "Most liked replies"
+    replies: Most liked replies
     views: Recent views
   view_explainer: One view per unique visitor every 8 hours.
   no_views: No view stats yet, check back later.
+  chart_error: Error rendering chart, please try again.
+  so_far: (so far)
   read: read
   minutes: min
+  today: Today
+  yesterday: Yesterday


### PR DESCRIPTION
Adds a prediction for today's views based on average views from past data:

![image](https://github.com/discourse/discourse-experimental-topic-map/assets/1681963/e68965ea-0eeb-4b91-836d-7bf487e093f0)


Also, since the chart is a little useless with <3 data points, a simple view: 

![image](https://github.com/discourse/discourse-experimental-topic-map/assets/1681963/9133db3b-9f39-4665-85d7-5662456cc82f)
