### PR TITLE
DEV: simplify and fix view charts

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -10,5 +10,3 @@ en:
   so_far: (so far)
   read: read
   minutes: min
-  today: Today
-  yesterday: Yesterday


### PR DESCRIPTION
the current implementation gets a bit twisted around with dates, especially if your local day isn't the same as the UTC day... this should simplify it to avoid those issues 

![image](https://github.com/discourse/discourse-experimental-topic-map/assets/1681963/f5c670ee-6b00-437f-8833-2669f926119f)

this also uses a weighted rolling average instead of a simply average to attempt and predict views for the current incomplete day